### PR TITLE
Simplified veth pairs naming

### DIFF
--- a/lib/distem/algorithm/network/tbf.rb
+++ b/lib/distem/algorithm/network/tbf.rb
@@ -30,7 +30,7 @@ module Distem
 
 
         def apply_filters(viface)
-          baseiface = Lib::NetTools::get_iface_name(viface.vnode, viface)
+          baseiface = Lib::NetTools::get_iface_name(viface)
           latency_mapping = viface.latency_filters.values.uniq
           nb_filters = latency_mapping.length
           if nb_filters > 255
@@ -130,8 +130,7 @@ module Distem
           @limited_bw_input = false
           @limited_lat_input = false
 
-          iface = Lib::NetTools::get_iface_name(vtraffic.viface.vnode,
-                                                vtraffic.viface)
+          iface = Lib::NetTools::get_iface_name(vtraffic.viface)
           baseiface = iface
           action = nil
           direction = nil
@@ -250,7 +249,7 @@ module Distem
             @@store[viface] = {}
           }
 
-          iface = Lib::NetTools::get_iface_name(viface.vnode,viface)
+          iface = Lib::NetTools::get_iface_name(viface)
 
           if (@limited_bw_output || @limited_lat_output)
             outputroot = TCWrapper::QdiscRoot.new(viface.ifb)

--- a/lib/distem/algorithm/network/tcalgorithm.rb
+++ b/lib/distem/algorithm/network/tcalgorithm.rb
@@ -1,6 +1,6 @@
 
 module Distem
-  module Algorithm 
+  module Algorithm
     module Network
 
       # A common interface for TC based algorithms
@@ -48,7 +48,7 @@ module Distem
             @@store[viface] = {}
           }
 
-          iface = Lib::NetTools::get_iface_name(viface.vnode,viface)
+          iface = Lib::NetTools::get_iface_name(viface)
           ifb = viface.ifb
 
           str = Lib::Shell.run("tc qdisc show || true").split(/\n/).grep(/ dev #{ifb} /)

--- a/lib/distem/distemlib/nettools.rb
+++ b/lib/distem/distemlib/nettools.rb
@@ -9,8 +9,6 @@ module Distem
       VXLAN_BRIDGE_PREFIX='vxlanbr'
       VXLAN_INTERFACE_PREFIX='vxlan'
       LOCALHOST='localhost' # :nodoc:
-      # Maximal size for a network interface name (from GNU/Linux specifications)
-      IFNAMEMAXSIZE=15
       @@nic_count=1
       @@addr_default=nil
       # Hash containing the (interface name, interface address, interface netmask) triplet
@@ -186,14 +184,9 @@ module Distem
       # ==== Returns
       # String object
       #
-      def self.get_iface_name(vnode,viface)
-        # >>> TODO: Remove vnode parameter)
-        raise unless vnode.is_a?(Resource::VNode)
+      def self.get_iface_name(viface)
         raise unless viface.is_a?(Resource::VIface)
-
-        ret = "#{vnode.name}-#{viface.name}-#{viface.id}"
-        binf = (ret.size >= IFNAMEMAXSIZE ? ret.size-IFNAMEMAXSIZE : 0)
-        ret = ret[binf..ret.size]
+        return "veth#{viface.id}"
       end
 
       # Gets the current MTU of a virtual network interface

--- a/lib/distem/node/container.rb
+++ b/lib/distem/node/container.rb
@@ -144,8 +144,8 @@ module Distem
         @@contsem.synchronize do
           LXCWrapper::Command.start(@vnode.name)
           @vnode.vifaces.each do |viface|
-            Lib::Shell::run("ethtool -K #{Lib::NetTools.get_iface_name(@vnode,viface)} gso off || true")
-            Lib::Shell::run("ethtool -K #{Lib::NetTools.get_iface_name(@vnode,viface)} tso off || true")
+            Lib::Shell::run("ethtool -K #{Lib::NetTools.get_iface_name(viface)} gso off || true")
+            Lib::Shell::run("ethtool -K #{Lib::NetTools.get_iface_name(viface)} tso off || true")
           end
           @cpuforge.apply
           @networkforges.each_value { |netforge| netforge.apply }

--- a/lib/distem/wrapper/lxc/configfile.rb
+++ b/lib/distem/wrapper/lxc/configfile.rb
@@ -63,7 +63,7 @@ module LXCWrapper # :nodoc: all
           f.puts "lxc.network.name = #{viface.name}"
           f.puts "lxc.network.flags = up"
           f.puts "lxc.network.hwaddr = #{viface.macaddress}"
-          f.puts "lxc.network.veth.pair = #{Distem::Lib::NetTools.get_iface_name(vnode,viface)}"
+          f.puts "lxc.network.veth.pair = #{Distem::Lib::NetTools.get_iface_name(viface)}"
           f.puts "lxc.network.ipv4 = #{viface.address.to_string}"
         end
 


### PR DESCRIPTION
Simplified the way veth pairs are named. Thus, it removes a limitation induced by the previous naming scheme that was leading sometimes to inconsistent veth naming.
